### PR TITLE
Use "classes" as a feature name

### DIFF
--- a/lib/featuretests.js
+++ b/lib/featuretests.js
@@ -28,7 +28,7 @@ function runIt(code) {
 		computedProperty: { passes: "'use strict'; var a = 1, b = { ['x'+a]: 2 };" },
 		moduleExport: { passes: "'use strict'; export var a = 1;" },
 		moduleImport: { passes: "'use strict'; import {a} from 'b';" },
-		"class": { passes: "'use strict'; class Foo {}; class Bar extends Foo {};" },
+		classes: { passes: "'use strict'; class Foo {}; class Bar extends Foo {};" },
 		numericLiteral: { passes: "'use strict'; var a = 0o1, b = 0b10;" },
 		oldOctalLiteral: { fails: "'use strict'; var a = 01;" },
 		symbol: { passes: "'use strict'; var a = Symbol('b');" },


### PR DESCRIPTION
Suggesting to use "classes" instead of the reserved word "class" as the name of the feature to avoid using the quotes(so is not the only feature with quotes)
